### PR TITLE
Added branch strategy

### DIFF
--- a/documentation/agreement/PULL_REQUESTS.md
+++ b/documentation/agreement/PULL_REQUESTS.md
@@ -11,3 +11,4 @@ Pull Requests
 - Review your own code before submitting a PR for review
 - Add a "Do not review" label to PRs that are not ready for review
 - If you're changing code, tag the person that originally wrote it
+- Delete the branch after merging

--- a/documentation/agreement/README.md
+++ b/documentation/agreement/README.md
@@ -11,6 +11,7 @@ These documents have been updated from SkaarDB:
 * [Release Process](RELEASE_STRATEGY.md)
 * [Meetings](MEETINGS.md)
 * [JIRA Tickets](TICKETS.md)
+* [Branch Strategy](BRANCH_STRATEGY.md)
 
 These are still direct copies of SkaarDB's Team Agreement:
 
@@ -35,7 +36,7 @@ These are still direct copies of SkaarDB's Team Agreement:
 ### Existing Parking Lot
 
 - PR template should have room to BE DESCRIPTIVE
-- Branching strategy. Master has to always be releasable. 
+- Branching strategy. Master has to always be releasable.
 - Contract testing in order to address dependent services
 - Ping each other when we’re deploying something that might break something else
 - What even are stories?
@@ -46,6 +47,3 @@ These are still direct copies of SkaarDB's Team Agreement:
 - Each repo has a CONTRIBUTING.md
 - Checkstyle. Possibly belongs in Contributing.
 - Testing requirements should be documented in the repo
-
-
-


### PR DESCRIPTION
The main goal is to eliminate the usage of forks in github so that we can get more realtime gitprime statistics. In discussing this with one fork advocate, a sticking point was that developers have less control over the vestigial branches that accumulate on the main repo than they do their own fork. So I've also added a note to our PR document about deleting merged branches to keep our main repositories clean.

I considered also talking about master and develop and releases and hotfixes and such, but I think that's outside of my goal for the moment. Let's make sure we get on the same page about those things eventually.

Discuss
![Discuss](https://media.giphy.com/media/l2SpQRuCQzY1RXHqM/giphy.gif)